### PR TITLE
Make the README example compile by removing the isNull check

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ const ptr = erased.cast(*u32);
 
 ptr.* = 42;
 
-std.debug.assert(!ptr.isNull());
 std.debug.assert(i == 42);
 ```
 


### PR DESCRIPTION
I initially fixed this by replacing it with a call to `erased.isNull`, but realized that would be misleading since `erased` will never be null in this example.

By deleting it, this is now basically the same code as in the test.